### PR TITLE
bypassing the lack of a license in fxdk

### DIFF
--- a/src/server/players.ts
+++ b/src/server/players.ts
@@ -277,6 +277,8 @@ export default class Players {
          * ```
          */
         getIdentifiers: (playerServerId: number) => {
+            const fxdkMode = GetConvarInt('sv_fxdkMode', 0);
+            
             const identifiers: {
                 steam?: string;
                 license?: string;
@@ -284,7 +286,9 @@ export default class Players {
                 discord?: string;
                 ip?: string;
                 [key: string]: any;
-            } = {};
+            } = {
+                license: fxdkMode ? 'fxdk_license' : undefined
+            };
 
             for (let i = 0; i < GetNumPlayerIdentifiers(String(playerServerId)); i++) {
                 const id = GetPlayerIdentifier(String(playerServerId), i).split(":");

--- a/src/server/players.ts
+++ b/src/server/players.ts
@@ -277,8 +277,7 @@ export default class Players {
          * ```
          */
         getIdentifiers: (playerServerId: number) => {
-            const fxdkMode = GetConvarInt('sv_fxdkMode', 0);
-            
+            const fxdkMode = GetConvarInt("sv_fxdkMode", 0);
             const identifiers: {
                 steam?: string;
                 license?: string;
@@ -287,7 +286,7 @@ export default class Players {
                 ip?: string;
                 [key: string]: any;
             } = {
-                license: fxdkMode ? 'fxdk_license' : undefined
+                license: fxdkMode ? "fxdk_license" : undefined
             };
 
             for (let i = 0; i < GetNumPlayerIdentifiers(String(playerServerId)); i++) {

--- a/src/server/players.ts
+++ b/src/server/players.ts
@@ -286,7 +286,7 @@ export default class Players {
                 ip?: string;
                 [key: string]: any;
             } = {
-                license: fxdkMode ? "fxdk_license" : undefined
+                license: fxdkMode ? "fxdk_license" : undefined,
             };
 
             for (let i = 0; i < GetNumPlayerIdentifiers(String(playerServerId)); i++) {


### PR DESCRIPTION
It is necessary because running a fivem client in a cfx.re developer kit, it does not provide a license identifier