### PR TITLE
Server playerConnecting event fix

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -464,7 +464,7 @@ export default class Server extends Events {
                 });
             }
 
-            return deferrals.done();
+            setImmediate(() => deferrals.done());
         },
 
         /**


### PR DESCRIPTION
It is required to wait for at least a tick before calling done after calling a prior deferral method.
Otherwise we get runtime error 'No current resource manager'.

https://docs.fivem.net/docs/scripting-reference/events/server-events/#playerconnecting
https://docs.fivem.net/docs/scripting-manual/runtimes/javascript/#thread-affinity